### PR TITLE
Registry now loads managers on registering.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="16" />
   </component>
   <component name="JavacSettings">
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -19,5 +19,5 @@
   <component name="PWA">
     <option name="wasEnabledAtLeastOnce" value="true" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ def bundleLibs = false
 def winConsole = false
 
 group projectGroup
-version '0.3.1-BETA'
+version '0.4-BETA-SNAPSHOT'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This PR adds a missing feature to the registry. When a manager is registered, the registry now will try to load it if the managers of its type (normal or fx) have already been loaded.